### PR TITLE
fix entity cleanup when transitioning scenes

### DIFF
--- a/src/scenes/bocce-game.lua
+++ b/src/scenes/bocce-game.lua
@@ -68,7 +68,7 @@ end
 function BocceGameScene:destroy()
 	SpriteManagerSingleton:remove(self.controllable_player)
 	SpriteManagerSingleton:remove(self.ai_player)
-	SpriteManagerSingleton:remove_all()
+	SpriteManagerSingleton:remove_all_of_type(Ball)
 end
 
 function BocceGameScene:build_payload()

--- a/src/systems/scene-manager.lua
+++ b/src/systems/scene-manager.lua
@@ -35,7 +35,7 @@ function SceneManager:next_state(state)
 	local payload = {}
 	if self.previous_state then
 		payload = self.previous_state:build_payload()
-		payload.source = self.previous_state.className
+		payload.source = self.previous_state
 		self.previous_state:destroy()
 	end
 	self.state = state

--- a/src/systems/sprite-manager.lua
+++ b/src/systems/sprite-manager.lua
@@ -44,10 +44,18 @@ function SpriteManager:add(sprite)
 end
 
 function SpriteManager:remove_all()
-	print("removing")
 	for i, active_sprite in ipairs(self.active_sprites) do
 		print(active_sprite.className)
 		if active_sprite:isa(sprite_class) then
+			active_sprite:remove()
+		end
+		table.remove(self.active_sprites, i)
+	end
+end
+
+function SpriteManager:remove_all_of_type(type)
+	for i, active_sprite in ipairs(self.active_sprites) do
+		if active_sprite:isa(type) then
 			active_sprite:remove()
 		end
 		table.remove(self.active_sprites, i)
@@ -99,4 +107,9 @@ function SpriteManager:update()
 	--a:collides_with(b)
 	--b:collides_with(a)
 	--end
+end
+
+function SpriteManager:count()
+	print("active: " .. #self.active_sprites)
+	print("inactive: " .. #self.inactive_sprites)
 end

--- a/src/systems/world-loader.lua
+++ b/src/systems/world-loader.lua
@@ -134,6 +134,10 @@ end
 function WorldLoaderSystem:load(level_id)
 	local level = self.world.levels[level_id]
 	self:publish(WorldLoaderSystem.EVENTS.LOAD_LEVEL, level)
+	if self.loaded_level == level.id then
+		return
+	end
+	self.loaded_level = level.id
 	for _, tile in ipairs(level.tiles) do
 		self:publish(WorldLoaderSystem.EVENTS.LOAD_TILE, tile)
 	end


### PR DESCRIPTION
This closes #32 by adding a `remove_all_of_type` method to `SpriteManager`, and by _not_ publishing messages from `WorldLoaderSystem` when we're loading the same level that was previously loaded.